### PR TITLE
CAF-3862: Updated to use opensuse base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     </modules>
 
     <properties>
-        <caf.base-container.policy-elasticsearch>cafinternal/prereleases:policy-elasticsearch-container-2.0.0-SNAPSHOT</caf.base-container.policy-elasticsearch>
+        <caf.base-container.policy-elasticsearch>cafinternal/prereleases:policy-elasticsearch-container-2.0.0-start_es-SNAPSHOT</caf.base-container.policy-elasticsearch>
         <caf.document.worker.version>3.1.1-71</caf.document.worker.version>
         <caf.binaryhash.version>2.1.0-28</caf.binaryhash.version>
         <caf.worker.binaryhash.container.name>cafdataprocessing/worker-binaryhash:2.1.0</caf.worker.binaryhash.container.name>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     </modules>
 
     <properties>
-        <caf.base-container.policy-elasticsearch>cafinternal/prereleases:policy-elasticsearch-container-2.0.0-start_es-SNAPSHOT</caf.base-container.policy-elasticsearch>
+        <caf.base-container.policy-elasticsearch>cafinternal/prereleases:policy-elasticsearch-container-2.0.0-SNAPSHOT</caf.base-container.policy-elasticsearch>
         <caf.document.worker.version>3.1.1-71</caf.document.worker.version>
         <caf.binaryhash.version>2.1.0-28</caf.binaryhash.version>
         <caf.worker.binaryhash.container.name>cafdataprocessing/worker-binaryhash:2.1.0</caf.worker.binaryhash.container.name>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     </modules>
 
     <properties>
-        <caf.base-container.policy-elasticsearch>cafdataprocessing/policy-elasticsearch-container:1.0.0-2</caf.base-container.policy-elasticsearch>
+        <caf.base-container.policy-elasticsearch>cafinternal/prereleases:policy-elasticsearch-container-2.0.0-SNAPSHOT</caf.base-container.policy-elasticsearch>
         <caf.document.worker.version>3.1.1-71</caf.document.worker.version>
         <caf.binaryhash.version>2.1.0-28</caf.binaryhash.version>
         <caf.worker.binaryhash.container.name>cafdataprocessing/worker-binaryhash:2.1.0</caf.worker.binaryhash.container.name>

--- a/worker-data-processing-container/pom.xml
+++ b/worker-data-processing-container/pom.xml
@@ -491,7 +491,7 @@
                             <alias>corepolicy-dbinstaller</alias>
                             <name>policy/dbinstaller</name>
                             <build>
-                                <from>java:8</from>
+                                <from>cafapi/opensuse-jre8:1.2</from>
                                 <tags>
                                     <tag>built-as-part-of-${project.parent.artifactId}-latest</tag>
                                     <tag>temporary-item-please-remove</tag>

--- a/worker-data-processing-container/pom.xml
+++ b/worker-data-processing-container/pom.xml
@@ -80,11 +80,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.cafapi</groupId>
-            <artifactId>container-cert-script</artifactId>
-            <type>tar.gz</type>
-        </dependency>
         <!-- database installer for use in testing container, not to be included in the worker container -->
         <dependency>
             <groupId>com.github.cafdataprocessing</groupId>
@@ -145,12 +140,6 @@
             <groupId>com.github.cafdataprocessing</groupId>
             <artifactId>worker-policy-testing</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.krallin</groupId>
-            <artifactId>tini</artifactId>
-            <scope>runtime</scope>
-            <type>exe</type>
         </dependency>
         <dependency>
             <groupId>com.github.workerframework</groupId>
@@ -556,13 +545,6 @@
                                 <volumes>
                                     <volume>${engine.environmentcache.location}</volume>
                                 </volumes>
-                                <!-- Run application through tini -->
-                                <entryPoint>
-                                    <exec>
-                                        <args>/opt/tini-${tini.version}.exe</args>
-                                        <args>--</args>
-                                    </exec>
-                                </entryPoint>
                                 <env>
                                     <POLICY_ELASTICSEARCH_DISABLED>true</POLICY_ELASTICSEARCH_DISABLED>
                                 </env>

--- a/worker-data-processing-container/src/main/docker/policyWorkerAssembly.xml
+++ b/worker-data-processing-container/src/main/docker/policyWorkerAssembly.xml
@@ -26,29 +26,9 @@
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
-                <exclude>com.github.cafapi:container-cert-script</exclude>
                 <exclude>com.github.cafdataprocessing:corepolicy-database</exclude>
-                <exclude>com.github.krallin:tini</exclude>
             </excludes>
             <outputDirectory>PolicyWorker</outputDirectory>
-        </dependencySet>
-
-        <!-- Explicitly specifying tini dependency so we can set execute permission on the file -->
-        <dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
-            <fileMode>0755</fileMode>
-            <includes>
-                <include>com.github.krallin:tini</include>
-            </includes>
-        </dependencySet>
-        <!-- unpack the container-cert-script tar so the script files are available to run -->
-        <dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <unpack>true</unpack>
-            <includes>
-                <include>com.github.cafapi:container-cert-script</include>
-            </includes>
         </dependencySet>
     </dependencySets>
     <files>

--- a/worker-data-processing-container/start.sh
+++ b/worker-data-processing-container/start.sh
@@ -77,7 +77,7 @@ should_start_elasticsearch() {
 start_elasticsearch() {
     /opt/elasticsearchConfig/configureElasticsearch.sh
     echo "Attempting to start Elasticsearch ..."
-    /opt/elasticsearch/bin/elasticsearch -Des.insecure.allow.root=true -d
+    /opt/elasticsearch/scripts/start.sh |& sed -ue 's/^/Elasticsearch: /' &
     if [ -n "$POLICY_ELASTICSEARCH_VERIFY_ATTEMPTS" ];
 	then
 	  remainingChecks=$POLICY_ELASTICSEARCH_VERIFY_ATTEMPTS

--- a/worker-data-processing-container/start.sh
+++ b/worker-data-processing-container/start.sh
@@ -172,5 +172,5 @@ fi
 
 #Launch the policyworker
 echo "CAF_WORKER_JAVA_OPTS " $CAF_WORKER_JAVA_OPTS
-exec java $CAF_WORKER_JAVA_OPTS -server -cp "/opt/PolicyWorker/*:/opt/PolicyWorker/lib/*:/opt/PolicyWorker/Handlers/*:/mnt/mesos/sandbox/*:/mnt/mesos/sandbox/handlers/*:/mnt/mesos/sandbox/converters/*:" com.hpe.caf.worker.core.WorkerApplication server ${logFile} |& sed -ue 's/^/Policy Worker: /' &
+exec java $CAF_WORKER_JAVA_OPTS -server -cp "/opt/PolicyWorker/*:/opt/PolicyWorker/lib/*:/opt/PolicyWorker/Handlers/*:/mnt/mesos/sandbox/*:/mnt/mesos/sandbox/handlers/*:/mnt/mesos/sandbox/converters/*:" com.hpe.caf.worker.core.WorkerApplication server ${logFile} |& sed -ue 's/^/Policy Worker: /'
 echo "ending setup"

--- a/worker-data-processing-container/start.sh
+++ b/worker-data-processing-container/start.sh
@@ -172,5 +172,5 @@ fi
 
 #Launch the policyworker
 echo "CAF_WORKER_JAVA_OPTS " $CAF_WORKER_JAVA_OPTS
-exec java $CAF_WORKER_JAVA_OPTS -server -cp "/opt/PolicyWorker/*:/opt/PolicyWorker/lib/*:/opt/PolicyWorker/Handlers/*:/mnt/mesos/sandbox/*:/mnt/mesos/sandbox/handlers/*:/mnt/mesos/sandbox/converters/*:" com.hpe.caf.worker.core.WorkerApplication server ${logFile}
+exec java $CAF_WORKER_JAVA_OPTS -server -cp "/opt/PolicyWorker/*:/opt/PolicyWorker/lib/*:/opt/PolicyWorker/Handlers/*:/mnt/mesos/sandbox/*:/mnt/mesos/sandbox/handlers/*:/mnt/mesos/sandbox/converters/*:" com.hpe.caf.worker.core.WorkerApplication server ${logFile} |& sed -ue 's/^/Policy Worker: /' &
 echo "ending setup"

--- a/worker-data-processing-container/start.sh
+++ b/worker-data-processing-container/start.sh
@@ -77,7 +77,7 @@ should_start_elasticsearch() {
 start_elasticsearch() {
     /opt/elasticsearchConfig/configureElasticsearch.sh
     echo "Attempting to start Elasticsearch ..."
-    /etc/init.d/elasticsearch start
+    /opt/elasticsearch/bin/elasticsearch -Des.insecure.allow.root=true -d
     if [ -n "$POLICY_ELASTICSEARCH_VERIFY_ATTEMPTS" ];
 	then
 	  remainingChecks=$POLICY_ELASTICSEARCH_VERIFY_ATTEMPTS
@@ -86,7 +86,7 @@ start_elasticsearch() {
 	fi
     while [ "$remainingChecks" -ne "0" ]
     do
-        if service elasticsearch status | grep -q "elasticsearch is running" && curl --silent http://localhost:9200/_cluster/health | grep -q 'cluster_name';
+        if curl --silent http://localhost:9200/_cluster/health | grep -q 'cluster_name';
         then
             echo "Elasticsearch started."
             remainingChecks=0
@@ -144,15 +144,6 @@ function set_logging_file_location(){
 }
 
 ####################################################
-# Installs a java certificate optionally passed into container.
-####################################################
-function install_certificate(){
-    #This will import the CA Cert from $MESOS_SANDBOX/$SSL_CA_CRT to the default Java keystore location depending on your distribution.
-    /opt/container-cert-script/install-ca-cert-java.sh
-}
-
-
-####################################################
 ####################################################
 # Start of actual execution.
 ####################################################
@@ -168,8 +159,6 @@ if (($?==1)); then
 fi;
 
 set_logging_file_location
-
-install_certificate
 
 # If the CAF_APPNAME and CAF_CONFIG_PATH environment variables are not set, then use the
 # JavaScript-encoded config files that are built into the container


### PR DESCRIPTION
The base image policy-elasticsearch-container has been updated to use a opensuse based base image.
Dev build: http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/view/Developer/job/CAFDataProcessing~worker-policy~CAF-3862~CI/